### PR TITLE
Feature/strategies

### DIFF
--- a/app/src/main/java/com/example/unimarket/data/SyncPayloads.kt
+++ b/app/src/main/java/com/example/unimarket/data/SyncPayloads.kt
@@ -34,3 +34,15 @@ data class PublishProductPayload(
     val imageUrls: List<String>,
     val status: String,
 )
+
+data class PublishWithImagePayload(
+    val majorId: String,
+    val classId: String,
+    val title: String,
+    val description: String,
+    val price: Double,
+    val labels: List<String>,
+    val localImageUri: String,
+    val remotePath: String,
+    val status: String,
+)

--- a/app/src/main/java/com/example/unimarket/ui/viewmodels/ExploreViewModel.kt
+++ b/app/src/main/java/com/example/unimarket/ui/viewmodels/ExploreViewModel.kt
@@ -54,7 +54,7 @@ class ExploreViewModel @Inject constructor(
     val isOnline: StateFlow<Boolean> = _isOnline.asStateFlow()
 
     companion object {
-        private const val DEFAULT_CACHE_TTL_MS = 3_600_000L
+        private const val DEFAULT_CACHE_TTL_MS = 300_000L
     }
 
 

--- a/app/src/main/java/com/example/unimarket/ui/viewmodels/ProductDetailViewModel.kt
+++ b/app/src/main/java/com/example/unimarket/ui/viewmodels/ProductDetailViewModel.kt
@@ -38,7 +38,7 @@ class ProductDetailViewModel @Inject constructor(
 ) : ViewModel() {
 
     companion object {
-        private const val DEFAULT_CACHE_TTL_MS = 3_600_000L // 1 hour
+        private const val DEFAULT_CACHE_TTL_MS = 300_000L // 5 minutes
     }
 
     private val productId: String = checkNotNull(savedStateHandle["productId"])

--- a/app/src/main/java/com/example/unimarket/ui/viewmodels/WishlistViewModel.kt
+++ b/app/src/main/java/com/example/unimarket/ui/viewmodels/WishlistViewModel.kt
@@ -33,7 +33,7 @@ class WishlistViewModel @Inject constructor(
     val wishListItems: StateFlow<List<WishlistItem>> = _items.asStateFlow()
 
     companion object {
-        private const val DEFAULT_CACHE_TTL_MS = 3_600_000L
+        private const val DEFAULT_CACHE_TTL_MS = 300_000L
     }
 
     init {

--- a/app/src/main/java/com/example/unimarket/ui/views/PublishProductScreen.kt
+++ b/app/src/main/java/com/example/unimarket/ui/views/PublishProductScreen.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -13,7 +14,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
@@ -33,7 +33,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -43,36 +42,38 @@ import androidx.navigation.NavController
 import coil.compose.rememberAsyncImagePainter
 import com.example.unimarket.ui.models.ClassItem
 import com.example.unimarket.ui.models.Major
-import com.example.unimarket.ui.viewmodels.ImageUploadState
 import com.example.unimarket.ui.viewmodels.PublishProductViewModel
+import com.example.unimarket.ui.viewmodels.PublishProductViewModel.ImageUploadState
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Composable
 fun PublishProductScreen(
     navController: NavController,
-    viewModel: PublishProductViewModel = hiltViewModel()
+    viewModel: PublishProductViewModel = hiltViewModel(),
 ) {
     val isOnline by viewModel.isOnline.collectAsState()
     val majors by viewModel.majors.collectAsState()
     val classes by viewModel.classes.collectAsState()
-    val scope        = rememberCoroutineScope()
     val snackbar = remember { SnackbarHostState() }
     val uiEvents = viewModel.uiEvent
-
     val uploadState by viewModel.uploadState.collectAsState()
+
+    var localPreviewUri by remember { mutableStateOf<Uri?>(null) }
 
     // Form state
     var selectedMajor by remember { mutableStateOf<Major?>(null) }
     var selectedClass by remember { mutableStateOf<ClassItem?>(null) }
     var expandedMajor by remember { mutableStateOf(false) }
     var expandedClass by remember { mutableStateOf(false) }
-
     var title by remember { mutableStateOf("") }
     var description by remember { mutableStateOf("") }
     var priceText by remember { mutableStateOf("") }
     var labelsText by remember { mutableStateOf("") }
-    var imageUrl by remember { mutableStateOf<String?>(null)}
+    var imageUrl by remember { mutableStateOf<String?>(null) }
 
+    val priceVal = priceText.toDoubleOrNull()
+
+    val uploadedImageUrl = (uploadState as? ImageUploadState.Success)?.remotePath.orEmpty()
 
     // Listen to UiEvents
     LaunchedEffect(Unit) {
@@ -87,17 +88,27 @@ fun PublishProductScreen(
         }
     }
 
+
     val picker = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri: Uri? ->
         uri?.let {
+            localPreviewUri = it
             viewModel.uploadImage(it)
         }
     }
 
+    val canPublish = listOf(
+        selectedMajor != null,
+        selectedClass != null,
+        title.isNotBlank(),
+        description.isNotBlank(),
+        priceVal != null,
+        localPreviewUri != null
+    ).all { it }
 
     Scaffold(
-        topBar       = { TopAppBar(title = { Text("Publish Product") }) },
+        topBar = { TopAppBar(title = { Text("Publish Product") }) },
         snackbarHost = { SnackbarHost(hostState = snackbar) }
     ) { padding ->
         Column(
@@ -109,9 +120,13 @@ fun PublishProductScreen(
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             if (!isOnline) {
-                OfflineBanner(
-                    message = "No internet - your product will be published when you reconnect",
-                    height = 45.dp
+                Text(
+                    "No connection: will queue until online",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                        .padding(8.dp)
                 )
             }
             // ─────────────────────────────────
@@ -218,49 +233,35 @@ fun PublishProductScreen(
 
             Button(
                 onClick = { picker.launch("image/*") },
-                enabled = isOnline,
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text("Select Image")
             }
-            when (uploadState) {
-                is ImageUploadState.Pending -> {
-                    CircularProgressIndicator()
-                }
-                is ImageUploadState.Failed -> {
-                    Text("Upload failed", color = MaterialTheme.colorScheme.error)
-                }
-                is ImageUploadState.Success -> {
-                    val url = (uploadState as ImageUploadState.Success).remotePath
-                    imageUrl = url
-                    Image(
-                        painter = rememberAsyncImagePainter(imageUrl),
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(200.dp)
-                    )
-                }
-                else -> Unit
+
+            localPreviewUri?.let { uri ->
+                Image(
+                    painter = rememberAsyncImagePainter(uri),
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxWidth().height(200.dp),
+                    contentScale = ContentScale.Crop
+                )
             }
 
             Spacer(Modifier.height(16.dp))
 
             Button(
                 onClick = {
-                    val price = priceText.toDoubleOrNull()
                     viewModel.publish(
                         selectedMajor,
                         selectedClass,
                         title,
                         description,
-                        price,
+                        priceVal,
                         labelsText.split(",").map(String::trim).filter(String::isNotEmpty),
-                        imageUrl ?: ""
+                        localPreviewUri,
                     )
                 },
-                enabled = true,
+                enabled = canPublish,
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text("Publish")


### PR DESCRIPTION
This pull request introduces functionality for handling product publishing with images, including queuing operations for offline scenarios and improving the user experience. Key changes include adding a new payload class, updating repository and worker logic, and enhancing the `PublishProductViewModel` and UI components.

### New functionality for publishing with images:

* **Payload and repository updates**:
  - Added `PublishWithImagePayload` to manage product publishing with local and remote image paths. (`SyncPayloads.kt`, [app/src/main/java/com/example/unimarket/data/SyncPayloads.ktR37-R48](diffhunk://#diff-e876df05c48451ee976e4de207c42a1423915848ff15a1f8c72b6e5534ee6d4dR37-R48))
  - Introduced `enqueuePublishWithImage` and `publishProductWithImage` methods in `UniMarketRepository` to handle image uploads and data synchronization. (`UniMarketRepository.kt`, [app/src/main/java/com/example/unimarket/data/UniMarketRepository.ktR241-R289](diffhunk://#diff-095196bb666935993673951677452f77c9a6b8099fa5b3e8c44eb41f9c77b0faR241-R289))

* **Worker logic enhancement**:
  - Updated `SyncWorker` to process the new "PUBLISH_WITH_IMAGE" operation type, including uploading images to remote storage and adding product data to Firestore. (`SyncWorker.kt`, [app/src/main/java/com/example/unimarket/data/SyncWorker.ktL136-R164](diffhunk://#diff-a4a9855c57541fb09ea53900f830bd3284f6cbda02efc7bfb8cf326f6ee816feL136-R164))

### ViewModel and UI improvements:

* **`PublishProductViewModel` enhancements**:
  - Added `ImageUploadState` to track the state of image uploads. (`PublishProductViewModel.kt`, [app/src/main/java/com/example/unimarket/ui/viewmodels/PublishProductViewModel.ktR69-R82](diffhunk://#diff-4d8c788aac203b09bcd5506d2b65e27e6f9fbe18ebe411e1889e48e10d143b76R69-R82))
  - Refactored product publishing logic to include image validation, queuing, and WorkManager integration for offline handling. (`PublishProductViewModel.kt`, [app/src/main/java/com/example/unimarket/ui/viewmodels/PublishProductViewModel.ktL130-R201](diffhunk://#diff-4d8c788aac203b09bcd5506d2b65e27e6f9fbe18ebe411e1889e48e10d143b76L130-R201))

* **UI updates for `PublishProductScreen`**:
  - Added local image preview and validation for publishing requirements. (`PublishProductScreen.kt`, [app/src/main/java/com/example/unimarket/ui/views/PublishProductScreen.ktR91-R108](diffhunk://#diff-fec74dbd8f44d2f88c66eebf9e5f912a68ef81fdbcaf8fd9207cc632adf2c6ceR91-R108))
  - Updated offline messaging to inform users about queuing behavior. (`PublishProductScreen.kt`, [app/src/main/java/com/example/unimarket/ui/views/PublishProductScreen.ktL112-R129](diffhunk://#diff-fec74dbd8f44d2f88c66eebf9e5f912a68ef81fdbcaf8fd9207cc632adf2c6ceL112-R129))

### Cache TTL adjustments:

* Reduced default cache TTL from 1 hour to 5 minutes in `ExploreViewModel`, `ProductDetailViewModel`, and `WishlistViewModel` for more frequent updates. (`ExploreViewModel.kt`, [[1]](diffhunk://#diff-d50355c7bf9c35e7c0f2d1aca638216593677235e7c381e26a783e51075cc4a0L57-R57); `ProductDetailViewModel.kt`, [[2]](diffhunk://#diff-da892f188e7e30ef69ad6600d4fc59c28486ddf860e93956e505fb4e49f42d96L41-R41); `WishlistViewModel.kt`, [[3]](diffhunk://#diff-c8880b865a2c380284188c00b0593940731c9241de31f2a68447c0c8625f5b90L36-R36)