### PR TITLE
REFINE: Update navigation in OrdersScreen

### DIFF
--- a/app/src/main/java/com/example/unimarket/ui/views/OrdersScreen.kt
+++ b/app/src/main/java/com/example/unimarket/ui/views/OrdersScreen.kt
@@ -109,8 +109,7 @@ fun OrdersScreen(
                             OrderItem(
                                 order        = order,
                                 onCardClick  = {
-                                    // navega a ProductDetailScreen
-                                    navController.navigate("productDetail/${order.productId}")
+                                    bottomNavController.navigate("productDetail/${order.productId}")
                                 },
                             )
                         }


### PR DESCRIPTION
This pull request includes a minor change to the `OrdersScreen` in `OrdersScreen.kt`, where the navigation controller used for navigating to the product detail screen was updated.

* [`app/src/main/java/com/example/unimarket/ui/views/OrdersScreen.kt`](diffhunk://#diff-d771a266dddcfc6c403721f37da7e1d739535352c3b7e968289f6a6e4617c59bL112-R112): Replaced `navController` with `bottomNavController` for navigating to the `ProductDetailScreen`